### PR TITLE
feat: add opt-in codespaces sync via gh cs cp

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ node node/copilot-token-cost.js --json     # machine-readable output
 | `--sync` | Force full re-sync of all log files into the database |
 | `--import-file FILE` | Import data from JSONL or SQLite file |
 | `--export-file FILE` | Export data as JSONL |
+| `--codespaces-sync` | Sync Copilot data from running Codespaces via `gh cs cp` |
+| `--codespaces-include-stopped` | Include stopped Codespaces (requires `--codespaces-sync`) |
 
 ## SQLite Database
 

--- a/copilot-token-cost.py
+++ b/copilot-token-cost.py
@@ -17,7 +17,9 @@ import argparse
 import db
 import json
 import re
+import subprocess
 import sys
+import tempfile
 import unicodedata
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -185,16 +187,19 @@ def project_name(cwd: str) -> str:
     return path
 
 
-def sync_logs_to_db(conn, logs_dir: Path, session_dir: Path, force: bool = False) -> int:
+def sync_logs_to_db(conn, logs_dir: Path, session_dir: Path, force: bool = False, source: str = 'local') -> int:
     """Parse log files and sync records into the SQLite database. Returns total new records inserted."""
-    existing = conn.execute("SELECT COUNT(*) FROM api_calls").fetchone()[0]
+    existing = conn.execute("SELECT COUNT(*) FROM api_calls WHERE source = ?", (source,)).fetchone()[0]
     log_files = sorted(logs_dir.glob("process-*.log"))
 
     if force:
         # Clear parse tracker so all logs are re-parsed; keep existing api_calls (INSERT OR IGNORE handles dedup)
-        conn.execute("DELETE FROM parsed_logs WHERE source = 'local'")
+        conn.execute("DELETE FROM parsed_logs WHERE source = ?", (source,))
         conn.commit()
-        print(f"  🔄 Force re-sync: re-parsing {len(log_files)} log files (keeping {existing:,} existing records)", file=sys.stderr)
+        print(
+            f"  🔄 Force re-sync ({source}): re-parsing {len(log_files)} log files (keeping {existing:,} existing records)",
+            file=sys.stderr
+        )
 
     total_inserted = 0
     parsed_count = 0
@@ -202,13 +207,13 @@ def sync_logs_to_db(conn, logs_dir: Path, session_dir: Path, force: bool = False
     for log_path in log_files:
         filename = log_path.name
         mtime = log_path.stat().st_mtime
-        if not force and db.is_log_parsed(conn, filename, mtime):
+        if not force and db.is_log_parsed(conn, filename, mtime, source=source):
             continue
         records = parse_log_file(log_path)
         for r in records:
             r['model_normalized'] = normalize_model(r['model'])
-        db.insert_records(conn, records)
-        db.mark_log_parsed(conn, filename, mtime, len(records))
+        db.insert_records(conn, records, source=source)
+        db.mark_log_parsed(conn, filename, mtime, len(records), source=source)
         total_inserted += len(records)
         parsed_count += 1
         if force:
@@ -216,14 +221,103 @@ def sync_logs_to_db(conn, logs_dir: Path, session_dir: Path, force: bool = False
 
     workspaces = load_session_workspaces(session_dir)
     for session_id, cwd in workspaces.items():
-        db.upsert_session_workspace(conn, session_id, cwd)
+        db.upsert_session_workspace(conn, session_id, cwd, source=source)
 
     if parsed_count > 0:
-        total_now = conn.execute("SELECT COUNT(*) FROM api_calls").fetchone()[0]
+        total_now = conn.execute("SELECT COUNT(*) FROM api_calls WHERE source = ?", (source,)).fetchone()[0]
         new_records = total_now - existing
-        print(f"  ✅ Synced {parsed_count} log files: {new_records:,} new records ({total_now:,} total in DB)", file=sys.stderr)
+        print(f"  ✅ Synced {parsed_count} log files ({source}): {new_records:,} new records ({total_now:,} total)", file=sys.stderr)
 
     return total_inserted
+
+
+def list_codespaces(include_stopped: bool) -> list[dict]:
+    """List codespaces to sync based on state filters."""
+    try:
+        proc = subprocess.run(
+            ["gh", "cs", "list", "--json", "name,state,lastUsedAt", "--limit", "1000"],
+            capture_output=True,
+            text=True,
+            check=False
+        )
+    except FileNotFoundError:
+        print("  ⚠️ Codespaces sync skipped: gh CLI not found", file=sys.stderr)
+        return []
+    if proc.returncode != 0:
+        stderr = (proc.stderr or '').strip()
+        print(f"  ⚠️ Codespaces sync skipped: {stderr or 'failed to list codespaces'}", file=sys.stderr)
+        return []
+    try:
+        items = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        print("  ⚠️ Codespaces sync skipped: invalid JSON from gh cs list", file=sys.stderr)
+        return []
+    allowed = {"Available"}
+    if include_stopped:
+        allowed.add("Shutdown")
+    return [cs for cs in items if cs.get("state") in allowed and cs.get("name")]
+
+
+def sync_codespaces_to_db(conn, include_stopped: bool = False) -> int:
+    """Sync ~/.copilot from codespaces via gh cs cp and import into DB sources."""
+    codespaces = list_codespaces(include_stopped=include_stopped)
+    if not codespaces:
+        return 0
+    total = 0
+    for cs in codespaces:
+        name = cs["name"]
+        state = cs.get("state", "")
+        last_used_at = cs.get("lastUsedAt")
+        if last_used_at and db.get_codespace_last_used(conn, name) == last_used_at:
+            print(f"  ⏭️  Skipping {name} (unchanged lastUsedAt)", file=sys.stderr)
+            continue
+
+        source = f"codespace:{name}"
+        should_stop = state == "Shutdown"
+        copied = False
+        try:
+            with tempfile.TemporaryDirectory(prefix="copilot-cs-") as tmp:
+                stage = Path(tmp) / name
+                stage.mkdir(parents=True, exist_ok=True)
+                try:
+                    cp = subprocess.run(
+                        ["gh", "cs", "cp", "-r", "-c", name, "remote:~/.copilot", str(stage)],
+                        capture_output=True,
+                        text=True,
+                        check=False
+                    )
+                except FileNotFoundError:
+                    print("  ⚠️ Codespaces sync skipped: gh CLI not found", file=sys.stderr)
+                    return total
+                if cp.returncode != 0:
+                    stderr = (cp.stderr or '').strip()
+                    print(f"  ⚠️ Failed to copy {name}: {stderr or 'gh cs cp failed'}", file=sys.stderr)
+                    continue
+
+                copilot_dir = stage / ".copilot"
+                logs_dir = copilot_dir / "logs"
+                session_dir = copilot_dir / "session-state"
+                if not logs_dir.exists():
+                    print(f"  ⚠️ Skipping {name}: no .copilot/logs in copied data", file=sys.stderr)
+                    continue
+
+                total += sync_logs_to_db(conn, logs_dir, session_dir, force=False, source=source)
+                copied = True
+        finally:
+            if should_stop:
+                try:
+                    subprocess.run(
+                        ["gh", "cs", "stop", "-c", name],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        check=False
+                    )
+                except FileNotFoundError:
+                    pass
+
+        if copied:
+            db.upsert_codespace_sync_state(conn, name, last_used_at)
+    return total
 
 
 # ─── Cost helpers ────────────────────────────────────────────────────────────
@@ -389,7 +483,12 @@ def main():
     parser.add_argument('--sync', action='store_true', help='Force full re-sync of all log files')
     parser.add_argument('--import-file', type=str, metavar='FILE', help='Import data from JSONL or SQLite file')
     parser.add_argument('--export-file', type=str, metavar='FILE', help='Export data as JSONL')
+    parser.add_argument('--codespaces-sync', action='store_true', help='Sync Copilot data from running Codespaces via gh cs cp')
+    parser.add_argument('--codespaces-include-stopped', action='store_true', help='Include stopped Codespaces (will wake and sync them)')
     args = parser.parse_args()
+
+    if args.codespaces_include_stopped and not args.codespaces_sync:
+        parser.error('--codespaces-include-stopped requires --codespaces-sync')
 
     home = Path.home()
     logs_dir = Path(args.logs_dir) if args.logs_dir else home / ".copilot" / "logs"
@@ -400,6 +499,9 @@ def main():
 
     if logs_dir.exists():
         sync_logs_to_db(conn, logs_dir, session_dir, force=args.sync)
+
+    if args.codespaces_sync:
+        sync_codespaces_to_db(conn, include_stopped=args.codespaces_include_stopped)
 
     if args.import_file:
         import_path = args.import_file

--- a/db.py
+++ b/db.py
@@ -39,6 +39,12 @@ CREATE TABLE IF NOT EXISTS session_workspaces (
     source TEXT DEFAULT 'local'
 );
 
+CREATE TABLE IF NOT EXISTS codespace_sync_state (
+    codespace_name TEXT PRIMARY KEY,
+    last_used_at TEXT,
+    last_synced_at TEXT NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_api_calls_timestamp ON api_calls(timestamp);
 CREATE INDEX IF NOT EXISTS idx_api_calls_model ON api_calls(model_normalized);
 CREATE INDEX IF NOT EXISTS idx_api_calls_session ON api_calls(session_id);
@@ -97,6 +103,25 @@ def upsert_session_workspace(conn, session_id: str, cwd: str, source: str = 'loc
     conn.execute(
         "INSERT OR REPLACE INTO session_workspaces (session_id, cwd, source) VALUES (?, ?, ?)",
         (session_id, cwd, source)
+    )
+    conn.commit()
+
+
+def get_codespace_last_used(conn, codespace_name: str) -> str | None:
+    """Return last_used_at recorded at the last successful sync for a codespace."""
+    row = conn.execute(
+        "SELECT last_used_at FROM codespace_sync_state WHERE codespace_name = ?",
+        (codespace_name,)
+    ).fetchone()
+    return row[0] if row else None
+
+
+def upsert_codespace_sync_state(conn, codespace_name: str, last_used_at: str | None):
+    """Record the latest successful sync marker for a codespace."""
+    conn.execute(
+        "INSERT OR REPLACE INTO codespace_sync_state (codespace_name, last_used_at, last_synced_at) "
+        "VALUES (?, ?, datetime('now'))",
+        (codespace_name, last_used_at)
     )
     conn.commit()
 

--- a/go/main.go
+++ b/go/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -159,23 +160,23 @@ func getPremiumMultiplier(model string, timestamp string) float64 {
 // ─── Record & Stats ─────────────────────────────────────────────────────────
 
 type Record struct {
-	Model              string
-	PromptTokens       int
-	CompletionTokens   int
+	Model               string
+	PromptTokens        int
+	CompletionTokens    int
 	CacheCreationTokens int
-	CacheReadTokens    int
-	IsUserTurn         bool
-	Timestamp          string
-	SessionID          string
-	LogFile            string
+	CacheReadTokens     int
+	IsUserTurn          bool
+	Timestamp           string
+	SessionID           string
+	LogFile             string
 }
 
 type Stats struct {
-	APICalls            int `json:"api_calls"`
-	PromptTokens        int `json:"prompt_tokens"`
-	CompletionTokens    int `json:"completion_tokens"`
-	CacheCreationTokens int `json:"cache_creation_tokens"`
-	CacheReadTokens     int `json:"cache_read_tokens"`
+	APICalls            int     `json:"api_calls"`
+	PromptTokens        int     `json:"prompt_tokens"`
+	CompletionTokens    int     `json:"completion_tokens"`
+	CacheCreationTokens int     `json:"cache_creation_tokens"`
+	CacheReadTokens     int     `json:"cache_read_tokens"`
 	PremiumRequests     float64 `json:"premium_requests"`
 }
 
@@ -269,15 +270,15 @@ func parseLogFile(logPath string) []Record {
 		}
 
 		records = append(records, Record{
-			Model:              lastModel,
-			PromptTokens:       promptTokens,
-			CompletionTokens:   completionTokens,
+			Model:               lastModel,
+			PromptTokens:        promptTokens,
+			CompletionTokens:    completionTokens,
 			CacheCreationTokens: cacheCreation,
-			CacheReadTokens:    cacheReadVal,
-			IsUserTurn:         lastInitiator == "user",
-			Timestamp:          lastTimestamp,
-			SessionID:          lastSession,
-			LogFile:            filepath.Base(logPath),
+			CacheReadTokens:     cacheReadVal,
+			IsUserTurn:          lastInitiator == "user",
+			Timestamp:           lastTimestamp,
+			SessionID:           lastSession,
+			LogFile:             filepath.Base(logPath),
 		})
 		lastInitiator = "agent"
 	}
@@ -338,6 +339,12 @@ CREATE TABLE IF NOT EXISTS session_workspaces (
     session_id TEXT PRIMARY KEY,
     cwd TEXT NOT NULL,
     source TEXT DEFAULT 'local'
+);
+
+CREATE TABLE IF NOT EXISTS codespace_sync_state (
+    codespace_name TEXT PRIMARY KEY,
+    last_used_at TEXT,
+    last_synced_at TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_api_calls_timestamp ON api_calls(timestamp);
@@ -430,6 +437,26 @@ func clearSource(db *sql.DB, source string) {
 	db.Exec("DELETE FROM api_calls WHERE source = ?", source)
 	db.Exec("DELETE FROM parsed_logs WHERE source = ?", source)
 	db.Exec("DELETE FROM session_workspaces WHERE source = ?", source)
+}
+
+func getCodespaceLastUsed(db *sql.DB, codespaceName string) string {
+	var lastUsed sql.NullString
+	err := db.QueryRow(
+		"SELECT last_used_at FROM codespace_sync_state WHERE codespace_name = ?",
+		codespaceName,
+	).Scan(&lastUsed)
+	if err != nil || !lastUsed.Valid {
+		return ""
+	}
+	return lastUsed.String
+}
+
+func upsertCodespaceSyncState(db *sql.DB, codespaceName string, lastUsedAt string) {
+	db.Exec(
+		"INSERT OR REPLACE INTO codespace_sync_state (codespace_name, last_used_at, last_synced_at) VALUES (?, ?, datetime('now'))",
+		codespaceName,
+		lastUsedAt,
+	)
 }
 
 func buildFilters(dateFrom, dateTo string) (string, []interface{}) {
@@ -723,16 +750,16 @@ func importSQLiteDB(db *sql.DB, otherDBPath, sourceOverride string) int {
 	return int(count)
 }
 
-func syncLogsToDB(db *sql.DB, logsDir, sessionDir string, force bool) int {
+func syncLogsToDB(db *sql.DB, logsDir, sessionDir string, force bool, source string) int {
 	var existing int
-	db.QueryRow("SELECT COUNT(*) FROM api_calls").Scan(&existing)
+	db.QueryRow("SELECT COUNT(*) FROM api_calls WHERE source = ?", source).Scan(&existing)
 	matches, _ := filepath.Glob(filepath.Join(logsDir, "process-*.log"))
 	sort.Strings(matches)
 
 	if force {
 		// Clear parse tracker so all logs are re-parsed; keep existing api_calls (INSERT OR IGNORE handles dedup)
-		db.Exec("DELETE FROM parsed_logs WHERE source = 'local'")
-		fmt.Fprintf(os.Stderr, "  🔄 Force re-sync: re-parsing %d log files (keeping %s existing records)\n", len(matches), addCommas(strconv.Itoa(existing)))
+		db.Exec("DELETE FROM parsed_logs WHERE source = ?", source)
+		fmt.Fprintf(os.Stderr, "  🔄 Force re-sync (%s): re-parsing %d log files (keeping %s existing records)\n", source, len(matches), addCommas(strconv.Itoa(existing)))
 	}
 
 	totalInserted := 0
@@ -745,12 +772,12 @@ func syncLogsToDB(db *sql.DB, logsDir, sessionDir string, force bool) int {
 			continue
 		}
 		mtime := float64(info.ModTime().UnixMilli()) / 1000.0
-		if !force && isLogParsed(db, filename, mtime, "local") {
+		if !force && isLogParsed(db, filename, mtime, source) {
 			continue
 		}
 		records := parseLogFile(logPath)
-		insertRecords(db, records, "local")
-		markLogParsed(db, filename, mtime, len(records), "local")
+		insertRecords(db, records, source)
+		markLogParsed(db, filename, mtime, len(records), source)
 		totalInserted += len(records)
 		parsedCount++
 		if force {
@@ -760,17 +787,104 @@ func syncLogsToDB(db *sql.DB, logsDir, sessionDir string, force bool) int {
 
 	workspaces := loadSessionWorkspaces(sessionDir)
 	for sessionID, cwd := range workspaces {
-		upsertSessionWorkspace(db, sessionID, cwd, "local")
+		upsertSessionWorkspace(db, sessionID, cwd, source)
 	}
 
 	if parsedCount > 0 {
 		var totalNow int
-		db.QueryRow("SELECT COUNT(*) FROM api_calls").Scan(&totalNow)
+		db.QueryRow("SELECT COUNT(*) FROM api_calls WHERE source = ?", source).Scan(&totalNow)
 		newRecords := totalNow - existing
-		fmt.Fprintf(os.Stderr, "  ✅ Synced %d log files: %s new records (%s total in DB)\n", parsedCount, addCommas(strconv.Itoa(newRecords)), addCommas(strconv.Itoa(totalNow)))
+		fmt.Fprintf(os.Stderr, "  ✅ Synced %d log files (%s): %s new records (%s total)\n", parsedCount, source, addCommas(strconv.Itoa(newRecords)), addCommas(strconv.Itoa(totalNow)))
 	}
 
 	return totalInserted
+}
+
+type codespaceInfo struct {
+	Name       string `json:"name"`
+	State      string `json:"state"`
+	LastUsedAt string `json:"lastUsedAt"`
+}
+
+func listCodespaces(includeStopped bool) []codespaceInfo {
+	cmd := exec.Command("gh", "cs", "list", "--json", "name,state,lastUsedAt", "--limit", "1000")
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠️ Codespaces sync skipped: failed to list codespaces\n")
+		return nil
+	}
+	var all []codespaceInfo
+	if err := json.Unmarshal(out, &all); err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠️ Codespaces sync skipped: invalid JSON from gh cs list\n")
+		return nil
+	}
+	allowed := map[string]bool{"Available": true}
+	if includeStopped {
+		allowed["Shutdown"] = true
+	}
+	var filtered []codespaceInfo
+	for _, cs := range all {
+		if cs.Name != "" && allowed[cs.State] {
+			filtered = append(filtered, cs)
+		}
+	}
+	return filtered
+}
+
+func syncCodespacesToDB(db *sql.DB, includeStopped bool) int {
+	codespaces := listCodespaces(includeStopped)
+	if len(codespaces) == 0 {
+		return 0
+	}
+	total := 0
+	for _, cs := range codespaces {
+		if cs.LastUsedAt != "" && getCodespaceLastUsed(db, cs.Name) == cs.LastUsedAt {
+			fmt.Fprintf(os.Stderr, "  ⏭️  Skipping %s (unchanged lastUsedAt)\n", cs.Name)
+			continue
+		}
+
+		shouldStop := cs.State == "Shutdown"
+		tmpDir, err := os.MkdirTemp("", "copilot-cs-")
+		if err != nil {
+			continue
+		}
+		copied := false
+		func() {
+			defer os.RemoveAll(tmpDir)
+			if shouldStop {
+				defer exec.Command("gh", "cs", "stop", "-c", cs.Name).Run()
+			}
+
+			stage := filepath.Join(tmpDir, cs.Name)
+			_ = os.MkdirAll(stage, 0755)
+			cpCmd := exec.Command("gh", "cs", "cp", "-r", "-c", cs.Name, "remote:~/.copilot", stage)
+			cpOut, cpErr := cpCmd.CombinedOutput()
+			if cpErr != nil {
+				msg := strings.TrimSpace(string(cpOut))
+				if msg == "" {
+					msg = "gh cs cp failed"
+				}
+				fmt.Fprintf(os.Stderr, "  ⚠️ Failed to copy %s: %s\n", cs.Name, msg)
+				return
+			}
+
+			copilotDir := filepath.Join(stage, ".copilot")
+			logsDir := filepath.Join(copilotDir, "logs")
+			sessionDir := filepath.Join(copilotDir, "session-state")
+			if _, err := os.Stat(logsDir); err != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠️ Skipping %s: no .copilot/logs in copied data\n", cs.Name)
+				return
+			}
+
+			total += syncLogsToDB(db, logsDir, sessionDir, false, "codespace:"+cs.Name)
+			copied = true
+		}()
+
+		if copied {
+			upsertCodespaceSyncState(db, cs.Name, cs.LastUsedAt)
+		}
+	}
+	return total
 }
 
 func projectName(cwd string) string {
@@ -936,20 +1050,48 @@ func displayWidth(s string) int {
 
 func isWideRune(r rune) bool {
 	// East Asian Width W/F ranges
-	if r >= 0x1100 && r <= 0x115F { return true }
-	if r >= 0x2E80 && r <= 0x303E { return true }
-	if r >= 0x3040 && r <= 0x33BF { return true }
-	if r >= 0x3400 && r <= 0x4DBF { return true }
-	if r >= 0x4E00 && r <= 0xA4CF { return true }
-	if r >= 0xA960 && r <= 0xA97C { return true }
-	if r >= 0xAC00 && r <= 0xD7FF { return true }
-	if r >= 0xF900 && r <= 0xFAFF { return true }
-	if r >= 0xFE10 && r <= 0xFE6F { return true }
-	if r >= 0xFF01 && r <= 0xFF60 { return true }
-	if r >= 0xFFE0 && r <= 0xFFE6 { return true }
-	if r >= 0x1F000 && r <= 0x1FFFF { return true }
-	if r >= 0x20000 && r <= 0x2FFFF { return true }
-	if r >= 0x30000 && r <= 0x3FFFF { return true }
+	if r >= 0x1100 && r <= 0x115F {
+		return true
+	}
+	if r >= 0x2E80 && r <= 0x303E {
+		return true
+	}
+	if r >= 0x3040 && r <= 0x33BF {
+		return true
+	}
+	if r >= 0x3400 && r <= 0x4DBF {
+		return true
+	}
+	if r >= 0x4E00 && r <= 0xA4CF {
+		return true
+	}
+	if r >= 0xA960 && r <= 0xA97C {
+		return true
+	}
+	if r >= 0xAC00 && r <= 0xD7FF {
+		return true
+	}
+	if r >= 0xF900 && r <= 0xFAFF {
+		return true
+	}
+	if r >= 0xFE10 && r <= 0xFE6F {
+		return true
+	}
+	if r >= 0xFF01 && r <= 0xFF60 {
+		return true
+	}
+	if r >= 0xFFE0 && r <= 0xFFE6 {
+		return true
+	}
+	if r >= 0x1F000 && r <= 0x1FFFF {
+		return true
+	}
+	if r >= 0x20000 && r <= 0x2FFFF {
+		return true
+	}
+	if r >= 0x30000 && r <= 0x3FFFF {
+		return true
+	}
 	return false
 }
 
@@ -1082,11 +1224,14 @@ func main() {
 	syncFlag := flag.Bool("sync", false, "Force full re-sync of all log files")
 	importFile := flag.String("import-file", "", "Import data from JSONL or SQLite file")
 	exportFile := flag.String("export-file", "", "Export data as JSONL")
+	codespacesSync := flag.Bool("codespaces-sync", false, "Sync Copilot data from running Codespaces via gh cs cp")
+	codespacesIncludeStopped := flag.Bool("codespaces-include-stopped", false, "Include stopped Codespaces (will wake and sync them)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: copilot-token-cost [days] [--all] [--today] [--yesterday]\n")
 		fmt.Fprintf(os.Stderr, "                         [--from N] [--to N] [--logs-dir PATH] [--json]\n")
 		fmt.Fprintf(os.Stderr, "                         [--sync] [--import-file FILE] [--export-file FILE]\n\n")
+		fmt.Fprintf(os.Stderr, "                         [--codespaces-sync] [--codespaces-include-stopped]\n\n")
 		fmt.Fprintf(os.Stderr, "Copilot CLI Token Cost Calculator\n\n")
 		fmt.Fprintf(os.Stderr, "Examples:\n")
 		fmt.Fprintf(os.Stderr, "  copilot-token-cost              # last 7 days\n")
@@ -1099,8 +1244,14 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  copilot-token-cost --sync       # force full re-sync\n")
 		fmt.Fprintf(os.Stderr, "  copilot-token-cost --export-file data.jsonl  # export\n")
 		fmt.Fprintf(os.Stderr, "  copilot-token-cost --import-file data.jsonl  # import\n")
+		fmt.Fprintf(os.Stderr, "  copilot-token-cost --codespaces-sync  # sync running codespaces\n")
 	}
 	flag.Parse()
+
+	if *codespacesIncludeStopped && !*codespacesSync {
+		fmt.Fprintln(os.Stderr, "--codespaces-include-stopped requires --codespaces-sync")
+		os.Exit(1)
+	}
 
 	home, _ := os.UserHomeDir()
 	logsDir := filepath.Join(home, ".copilot", "logs")
@@ -1201,7 +1352,11 @@ func main() {
 	defer database.Close()
 
 	if logsExist {
-		syncLogsToDB(database, logsDir, sessionDir, *syncFlag)
+		syncLogsToDB(database, logsDir, sessionDir, *syncFlag, "local")
+	}
+
+	if *codespacesSync {
+		syncCodespacesToDB(database, *codespacesIncludeStopped)
 	}
 
 	if *importFile != "" {
@@ -1319,16 +1474,16 @@ func main() {
 		}
 
 		type output struct {
-			Period                string                       `json:"period"`
-			DateRange             *string                      `json:"date_range"`
-			LogFiles              int                          `json:"log_files"`
-			APICalls              int                          `json:"api_calls"`
-			Models                map[string]jsonStats         `json:"models"`
-			Daily                 map[string]map[string]interface{} `json:"daily"`
-			Projects              map[string]jsonStats         `json:"projects"`
-			TotalCost             float64                      `json:"total_cost"`
-			TotalCostNoCache      float64                      `json:"total_cost_without_cache"`
-			TotalPremiumRequestCost float64                    `json:"total_premium_request_cost"`
+			Period                  string                            `json:"period"`
+			DateRange               *string                           `json:"date_range"`
+			LogFiles                int                               `json:"log_files"`
+			APICalls                int                               `json:"api_calls"`
+			Models                  map[string]jsonStats              `json:"models"`
+			Daily                   map[string]map[string]interface{} `json:"daily"`
+			Projects                map[string]jsonStats              `json:"projects"`
+			TotalCost               float64                           `json:"total_cost"`
+			TotalCostNoCache        float64                           `json:"total_cost_without_cache"`
+			TotalPremiumRequestCost float64                           `json:"total_premium_request_cost"`
 		}
 
 		out := output{
@@ -1357,8 +1512,8 @@ func main() {
 				CompletionTokens: s.CompletionTokens, CacheCreationTokens: s.CacheCreationTokens,
 				CacheReadTokens: s.CacheReadTokens, PremiumRequests: s.PremiumRequests,
 				PremiumRequestCost: roundN(premCost, 4),
-				InputUncached: uncachedInput(s),
-				Cost: roundN(cost, 4), CostWithoutCache: roundN(costNC, 4),
+				InputUncached:      uncachedInput(s),
+				Cost:               roundN(cost, 4), CostWithoutCache: roundN(costNC, 4),
 			}
 			out.TotalPremiumRequestCost += premCost
 		}
@@ -1378,8 +1533,8 @@ func main() {
 					CompletionTokens: s.CompletionTokens, CacheCreationTokens: s.CacheCreationTokens,
 					CacheReadTokens: s.CacheReadTokens, PremiumRequests: s.PremiumRequests,
 					PremiumRequestCost: roundN(s.PremiumRequests*getPremiumRequestCost(day), 4),
-					InputUncached: uncachedInput(s),
-					Cost: roundN(cost, 4), CostWithoutCache: roundN(costNC, 4),
+					InputUncached:      uncachedInput(s),
+					Cost:               roundN(cost, 4), CostWithoutCache: roundN(costNC, 4),
 				}
 			}
 			dayMap["_total_cost"] = roundN(dayTotal, 4)
@@ -1415,8 +1570,8 @@ func main() {
 				CompletionTokens: s.CompletionTokens, CacheCreationTokens: s.CacheCreationTokens,
 				CacheReadTokens: s.CacheReadTokens, PremiumRequests: s.PremiumRequests,
 				PremiumRequestCost: roundN(s.PremiumRequests*getPremiumRequestCost(""), 4),
-				InputUncached: uncachedInput(s),
-				Cost: roundN(pc[0], 4), CostWithoutCache: roundN(pc[1], 4),
+				InputUncached:      uncachedInput(s),
+				Cost:               roundN(pc[0], 4), CostWithoutCache: roundN(pc[1], 4),
 			}
 		}
 

--- a/node/copilot-token-cost.js
+++ b/node/copilot-token-cost.js
@@ -14,6 +14,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { spawnSync } = require('child_process');
 const Database = require('better-sqlite3');
 
 const DB_PATH = path.join(__dirname, '..', 'copilot-tokens.db');
@@ -85,6 +86,11 @@ CREATE TABLE IF NOT EXISTS session_workspaces (
     cwd TEXT NOT NULL,
     source TEXT DEFAULT 'local'
 );
+CREATE TABLE IF NOT EXISTS codespace_sync_state (
+    codespace_name TEXT PRIMARY KEY,
+    last_used_at TEXT,
+    last_synced_at TEXT NOT NULL
+);
 CREATE INDEX IF NOT EXISTS idx_api_calls_timestamp ON api_calls(timestamp);
 CREATE INDEX IF NOT EXISTS idx_api_calls_model ON api_calls(model_normalized);
 CREATE INDEX IF NOT EXISTS idx_api_calls_session ON api_calls(session_id);
@@ -146,6 +152,21 @@ function clearSource(db, source = 'local') {
   db.prepare('DELETE FROM api_calls WHERE source = ?').run(source);
   db.prepare('DELETE FROM parsed_logs WHERE source = ?').run(source);
   db.prepare('DELETE FROM session_workspaces WHERE source = ?').run(source);
+}
+
+
+function getCodespaceLastUsed(db, codespaceName) {
+  const row = db.prepare(
+    'SELECT last_used_at FROM codespace_sync_state WHERE codespace_name = ?'
+  ).get(codespaceName);
+  return row ? row.last_used_at : null;
+}
+
+
+function upsertCodespaceSyncState(db, codespaceName, lastUsedAt) {
+  db.prepare(
+    "INSERT OR REPLACE INTO codespace_sync_state (codespace_name, last_used_at, last_synced_at) VALUES (?, ?, datetime('now'))"
+  ).run(codespaceName, lastUsedAt ?? null);
 }
 
 
@@ -335,8 +356,8 @@ function importSQLiteDB(db, otherDBPath, sourceOverride) {
 }
 
 
-function syncLogsToDB(db, logsDir, sessionDir, force = false) {
-  const existing = db.prepare('SELECT COUNT(*) AS c FROM api_calls').get().c;
+function syncLogsToDB(db, logsDir, sessionDir, force = false, source = 'local') {
+  const existing = db.prepare('SELECT COUNT(*) AS c FROM api_calls WHERE source = ?').get(source).c;
   const logFiles = fs.readdirSync(logsDir)
     .filter(f => f.startsWith('process-') && f.endsWith('.log'))
     .sort()
@@ -344,8 +365,8 @@ function syncLogsToDB(db, logsDir, sessionDir, force = false) {
 
   // Clear parse tracker so all logs are re-parsed; keep existing api_calls (INSERT OR IGNORE handles dedup)
   if (force) {
-    db.exec("DELETE FROM parsed_logs WHERE source = 'local'");
-    process.stderr.write(`  🔄 Force re-sync: re-parsing ${logFiles.length} log files (keeping ${existing.toLocaleString()} existing records)\n`);
+    db.prepare('DELETE FROM parsed_logs WHERE source = ?').run(source);
+    process.stderr.write(`  🔄 Force re-sync (${source}): re-parsing ${logFiles.length} log files (keeping ${existing.toLocaleString()} existing records)\n`);
   }
   let totalInserted = 0;
   let parsedCount = 0;
@@ -353,11 +374,11 @@ function syncLogsToDB(db, logsDir, sessionDir, force = false) {
   for (const logPath of logFiles) {
     const filename = path.basename(logPath);
     const mtime = fs.statSync(logPath).mtimeMs / 1000;
-    if (!force && isLogParsed(db, filename, mtime)) continue;
+    if (!force && isLogParsed(db, filename, mtime, source)) continue;
     const records = parseLogFile(logPath);
     records.forEach(r => { r.model_normalized = normalizeModel(r.model); });
-    insertRecords(db, records);
-    markLogParsed(db, filename, mtime, records.length);
+    insertRecords(db, records, source);
+    markLogParsed(db, filename, mtime, records.length, source);
     totalInserted += records.length;
     parsedCount++;
     if (force) {
@@ -366,14 +387,82 @@ function syncLogsToDB(db, logsDir, sessionDir, force = false) {
   }
   const workspaces = loadSessionWorkspaces(sessionDir);
   for (const [sid, cwd] of Object.entries(workspaces)) {
-    upsertSessionWorkspace(db, sid, cwd);
+    upsertSessionWorkspace(db, sid, cwd, source);
   }
   if (parsedCount > 0) {
-    const totalNow = db.prepare('SELECT COUNT(*) AS c FROM api_calls').get().c;
+    const totalNow = db.prepare('SELECT COUNT(*) AS c FROM api_calls WHERE source = ?').get(source).c;
     const newRecords = totalNow - existing;
-    process.stderr.write(`  ✅ Synced ${parsedCount} log files: ${newRecords.toLocaleString()} new records (${totalNow.toLocaleString()} total in DB)\n`);
+    process.stderr.write(`  ✅ Synced ${parsedCount} log files (${source}): ${newRecords.toLocaleString()} new records (${totalNow.toLocaleString()} total)\n`);
   }
   return totalInserted;
+}
+
+
+function listCodespaces(includeStopped = false) {
+  const proc = spawnSync('gh', ['cs', 'list', '--json', 'name,state,lastUsedAt', '--limit', '1000'], { encoding: 'utf-8' });
+  if (proc.status !== 0) {
+    const err = (proc.stderr || '').trim();
+    process.stderr.write(`  ⚠️ Codespaces sync skipped: ${err || 'failed to list codespaces'}\n`);
+    return [];
+  }
+  let items = [];
+  try {
+    items = JSON.parse(proc.stdout || '[]');
+  } catch {
+    process.stderr.write('  ⚠️ Codespaces sync skipped: invalid JSON from gh cs list\n');
+    return [];
+  }
+  const allowed = new Set(['Available']);
+  if (includeStopped) allowed.add('Shutdown');
+  return items.filter(cs => cs.name && allowed.has(cs.state));
+}
+
+
+function syncCodespacesToDB(db, includeStopped = false) {
+  const codespaces = listCodespaces(includeStopped);
+  if (!codespaces.length) return 0;
+  let total = 0;
+  for (const cs of codespaces) {
+    const name = cs.name;
+    const state = cs.state || '';
+    const lastUsedAt = cs.lastUsedAt ?? null;
+    if (lastUsedAt && getCodespaceLastUsed(db, name) === lastUsedAt) {
+      process.stderr.write(`  ⏭️  Skipping ${name} (unchanged lastUsedAt)\n`);
+      continue;
+    }
+
+    const shouldStop = state === 'Shutdown';
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-cs-'));
+    let copied = false;
+    try {
+      const stage = path.join(tmpDir, name);
+      fs.mkdirSync(stage, { recursive: true });
+      const cp = spawnSync('gh', ['cs', 'cp', '-r', '-c', name, 'remote:~/.copilot', stage], { encoding: 'utf-8' });
+      if (cp.status !== 0) {
+        const err = (cp.stderr || '').trim();
+        process.stderr.write(`  ⚠️ Failed to copy ${name}: ${err || 'gh cs cp failed'}\n`);
+        continue;
+      }
+
+      const copilotDir = path.join(stage, '.copilot');
+      const logsDir = path.join(copilotDir, 'logs');
+      const sessionDir = path.join(copilotDir, 'session-state');
+      if (!fs.existsSync(logsDir)) {
+        process.stderr.write(`  ⚠️ Skipping ${name}: no .copilot/logs in copied data\n`);
+        continue;
+      }
+      total += syncLogsToDB(db, logsDir, sessionDir, false, `codespace:${name}`);
+      copied = true;
+    } finally {
+      if (shouldStop) {
+        spawnSync('gh', ['cs', 'stop', '-c', name], { stdio: 'ignore' });
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    if (copied) upsertCodespaceSyncState(db, name, lastUsedAt);
+  }
+  return total;
 }
 
 
@@ -742,6 +831,8 @@ function parseArgs(argv) {
     sync: false,
     import_file: null,
     export_file: null,
+    codespaces_sync: false,
+    codespaces_include_stopped: false,
   };
   const positional = [];
   let i = 0;
@@ -752,6 +843,8 @@ function parseArgs(argv) {
     else if (a === '--yesterday') { args.yesterday = true; }
     else if (a === '--json') { args.json = true; }
     else if (a === '--sync') { args.sync = true; }
+    else if (a === '--codespaces-sync') { args.codespaces_sync = true; }
+    else if (a === '--codespaces-include-stopped') { args.codespaces_include_stopped = true; }
     else if (a === '--help' || a === '-h') { args.help = true; }
     else if (a === '--from') { i++; args.from_days = parseInt(argv[i], 10); }
     else if (a === '--to') { i++; args.to_days = parseInt(argv[i], 10); }
@@ -766,6 +859,10 @@ function parseArgs(argv) {
     i++;
   }
   if (positional.length > 0) args.days = positional[0];
+  if (args.codespaces_include_stopped && !args.codespaces_sync) {
+    process.stderr.write('--codespaces-include-stopped requires --codespaces-sync\n');
+    process.exit(1);
+  }
   return args;
 }
 
@@ -774,6 +871,7 @@ function showHelp() {
   console.log(`usage: copilot-token-cost.js [days] [--all] [--today] [--yesterday]
                             [--from N] [--to N] [--logs-dir PATH] [--json]
                             [--sync] [--import-file FILE] [--export-file FILE]
+                            [--codespaces-sync] [--codespaces-include-stopped]
 
 Copilot CLI Token Cost Calculator
 
@@ -792,6 +890,9 @@ options:
   --sync                Force full re-sync of all log files
   --import-file FILE    Import data from JSONL or SQLite file
   --export-file FILE    Export data as JSONL
+  --codespaces-sync     Sync Copilot data from running Codespaces via gh cs cp
+  --codespaces-include-stopped
+                        Include stopped Codespaces (will wake and sync them)
 
 Examples:
   copilot-token-cost.js              # last 7 days
@@ -876,6 +977,10 @@ function main() {
 
   if (fs.existsSync(logsDir)) {
     syncLogsToDB(db, logsDir, sessionDir, args.sync);
+  }
+
+  if (args.codespaces_sync) {
+    syncCodespacesToDB(db, args.codespaces_include_stopped);
   }
 
   if (args.import_file) {


### PR DESCRIPTION
## Summary
- add `--codespaces-sync` and `--codespaces-include-stopped` flags across Python, Go, and Node CLIs
- sync codespace Copilot data sequentially via `gh cs cp -r remote:~/.copilot`
- tag imported records as `codespace:<name>` and persist per-codespace `lastUsedAt` sync state
- auto-stop codespaces that were initially `Shutdown` after sync
- document new flags in README

## Validation
- `python3 -m py_compile copilot-token-cost.py db.py`
- `python3 copilot-token-cost.py --help`
- `node node/copilot-token-cost.js --help`
- `gofmt -w go/main.go && (cd go && go build -o /tmp/copilot-token-cost-new .)`
- flag guard check: `--codespaces-include-stopped` requires `--codespaces-sync`
