### PR TITLE
fix: ingest and attribute codespace usage correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ node node/copilot-token-cost.js --json     # machine-readable output
 | `--to N` | End at N days ago (0=today) |
 | `--logs-dir PATH` | Override logs directory |
 | `--json` | Machine-readable JSON output |
-| `--sync` | Force full re-sync of all log files into the database |
+| `--sync` | Force full re-sync of all log files into the database (including codespaces when `--codespaces-sync` is used) |
 | `--import-file FILE` | Import data from JSONL or SQLite file |
 | `--export-file FILE` | Export data as JSONL |
 | `--codespaces-sync` | Sync Copilot data from running Codespaces via `gh cs cp` |

--- a/copilot-token-cost.py
+++ b/copilot-token-cost.py
@@ -258,7 +258,7 @@ def list_codespaces(include_stopped: bool) -> list[dict]:
     return [cs for cs in items if cs.get("state") in allowed and cs.get("name")]
 
 
-def sync_codespaces_to_db(conn, include_stopped: bool = False) -> int:
+def sync_codespaces_to_db(conn, include_stopped: bool = False, force: bool = False) -> int:
     """Sync ~/.copilot from codespaces via gh cs cp and import into DB sources."""
     codespaces = list_codespaces(include_stopped=include_stopped)
     if not codespaces:
@@ -281,7 +281,7 @@ def sync_codespaces_to_db(conn, include_stopped: bool = False) -> int:
                 stage.mkdir(parents=True, exist_ok=True)
                 try:
                     cp = subprocess.run(
-                        ["gh", "cs", "cp", "-r", "-c", name, "remote:~/.copilot", str(stage)],
+                        ["gh", "cs", "cp", "-e", "-r", "-c", name, "remote:/home/vscode/.copilot", str(stage)],
                         capture_output=True,
                         text=True,
                         check=False
@@ -291,17 +291,24 @@ def sync_codespaces_to_db(conn, include_stopped: bool = False) -> int:
                     return total
                 if cp.returncode != 0:
                     stderr = (cp.stderr or '').strip()
-                    print(f"  ⚠️ Failed to copy {name}: {stderr or 'gh cs cp failed'}", file=sys.stderr)
+                    if "No such file or directory" in stderr:
+                        print(f"  ⚠️ Skipping {name}: /home/vscode/.copilot not found", file=sys.stderr)
+                    else:
+                        print(f"  ⚠️ Failed to copy {name}: {stderr or 'gh cs cp failed'}", file=sys.stderr)
                     continue
 
                 copilot_dir = stage / ".copilot"
+                if not (copilot_dir / "logs").exists():
+                    alt = stage / "home" / "vscode" / ".copilot"
+                    if (alt / "logs").exists():
+                        copilot_dir = alt
                 logs_dir = copilot_dir / "logs"
                 session_dir = copilot_dir / "session-state"
                 if not logs_dir.exists():
                     print(f"  ⚠️ Skipping {name}: no .copilot/logs in copied data", file=sys.stderr)
                     continue
 
-                total += sync_logs_to_db(conn, logs_dir, session_dir, force=False, source=source)
+                total += sync_logs_to_db(conn, logs_dir, session_dir, force=force, source=source)
                 copied = True
         finally:
             if should_stop:
@@ -501,7 +508,7 @@ def main():
         sync_logs_to_db(conn, logs_dir, session_dir, force=args.sync)
 
     if args.codespaces_sync:
-        sync_codespaces_to_db(conn, include_stopped=args.codespaces_include_stopped)
+        sync_codespaces_to_db(conn, include_stopped=args.codespaces_include_stopped, force=args.sync)
 
     if args.import_file:
         import_path = args.import_file
@@ -584,7 +591,7 @@ def main():
 
     # ─── Get filtered records and session workspaces for per-project cost calc ─
     filtered_records = db.query_records(conn, date_from, date_to)
-    session_workspaces = db.query_session_workspaces(conn)
+    session_workspaces = db.query_session_workspaces_by_source(conn)
 
     total_records = sum(s['api_calls'] for s in model_stats.values())
     log_file_count = conn.execute(
@@ -640,7 +647,8 @@ def main():
         proj_costs = defaultdict(lambda: {'cost': 0.0, 'cost_without_cache': 0.0})
         for r in filtered_records:
             sid = r.get('session_id')
-            cwd = session_workspaces.get(sid, '') if sid else ''
+            src = r.get('source', '')
+            cwd = session_workspaces.get((sid, src), '') if sid else ''
             proj = project_name(cwd) if cwd else '(unknown)'
             model = normalize_model(r['model'])
             rs = {'prompt_tokens': r['prompt_tokens'], 'completion_tokens': r['completion_tokens'],
@@ -779,7 +787,8 @@ def main():
     proj_costs = defaultdict(lambda: {'cost': 0.0, 'cost_nc': 0.0})
     for r in filtered_records:
         sid = r.get('session_id')
-        cwd = session_workspaces.get(sid, '') if sid else ''
+        src = r.get('source', '')
+        cwd = session_workspaces.get((sid, src), '') if sid else ''
         proj = project_name(cwd) if cwd else '(unknown)'
         model = normalize_model(r['model'])
         rs = {'prompt_tokens': r['prompt_tokens'], 'completion_tokens': r['completion_tokens'],

--- a/db.py
+++ b/db.py
@@ -34,9 +34,10 @@ CREATE TABLE IF NOT EXISTS parsed_logs (
 );
 
 CREATE TABLE IF NOT EXISTS session_workspaces (
-    session_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
     cwd TEXT NOT NULL,
-    source TEXT DEFAULT 'local'
+    source TEXT DEFAULT 'local',
+    PRIMARY KEY (session_id, source)
 );
 
 CREATE TABLE IF NOT EXISTS codespace_sync_state (
@@ -59,7 +60,37 @@ def get_connection(db_path: Path = None) -> sqlite3.Connection:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
     conn.executescript(SCHEMA_SQL)
+    migrate_session_workspaces_schema(conn)
     return conn
+
+
+def migrate_session_workspaces_schema(conn):
+    """Migrate session_workspaces to composite PK (session_id, source) for source-safe joins."""
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='session_workspaces'"
+    ).fetchone()
+    if not table_exists:
+        return
+    pk_cols = [
+        row[1]
+        for row in conn.execute("PRAGMA table_info(session_workspaces)").fetchall()
+        if row[5] > 0
+    ]
+    if pk_cols == ['session_id', 'source']:
+        return
+    conn.executescript("""
+    ALTER TABLE session_workspaces RENAME TO session_workspaces_old;
+    CREATE TABLE session_workspaces (
+        session_id TEXT NOT NULL,
+        cwd TEXT NOT NULL,
+        source TEXT DEFAULT 'local',
+        PRIMARY KEY (session_id, source)
+    );
+    INSERT OR REPLACE INTO session_workspaces (session_id, cwd, source)
+    SELECT session_id, cwd, COALESCE(source, 'local') FROM session_workspaces_old;
+    DROP TABLE session_workspaces_old;
+    """)
+    conn.commit()
 
 
 def is_log_parsed(conn, log_file: str, mtime: float, source: str = 'local') -> bool:
@@ -316,7 +347,8 @@ def query_project_stats(conn, date_from=None, date_to=None, source=None) -> dict
         "SUM(a.cache_creation_tokens) AS cache_creation_tokens, "
         "SUM(a.cache_read_tokens) AS cache_read_tokens, "
         "SUM(CASE WHEN a.is_user_turn = 1 THEN 1 ELSE 0 END) AS user_turns "
-        f"FROM api_calls a LEFT JOIN session_workspaces sw ON a.session_id = sw.session_id{where} "
+        f"FROM api_calls a LEFT JOIN session_workspaces sw "
+        f"ON a.session_id = sw.session_id AND a.source = sw.source{where} "
         "GROUP BY cwd"
     )
     result = {}
@@ -356,6 +388,18 @@ def query_session_workspaces(conn, source=None) -> dict:
     else:
         rows = conn.execute("SELECT session_id, cwd FROM session_workspaces")
     return {row[0]: row[1] for row in rows}
+
+
+def query_session_workspaces_by_source(conn, source=None) -> dict:
+    """Return {(session_id, source): cwd} dict, optionally filtered by source."""
+    if source is not None:
+        rows = conn.execute(
+            "SELECT session_id, cwd, source FROM session_workspaces WHERE source = ?",
+            (source,)
+        )
+    else:
+        rows = conn.execute("SELECT session_id, cwd, source FROM session_workspaces")
+    return {(row[0], row[2]): row[1] for row in rows}
 
 
 def clear_source(conn, source: str = 'local'):

--- a/go/main.go
+++ b/go/main.go
@@ -169,6 +169,7 @@ type Record struct {
 	Timestamp           string
 	SessionID           string
 	LogFile             string
+	Source              string
 }
 
 type Stats struct {
@@ -336,9 +337,10 @@ CREATE TABLE IF NOT EXISTS parsed_logs (
 );
 
 CREATE TABLE IF NOT EXISTS session_workspaces (
-    session_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
     cwd TEXT NOT NULL,
-    source TEXT DEFAULT 'local'
+    source TEXT DEFAULT 'local',
+    PRIMARY KEY (session_id, source)
 );
 
 CREATE TABLE IF NOT EXISTS codespace_sync_state (
@@ -382,7 +384,32 @@ func initDB(dbPath string) *sql.DB {
 		fmt.Fprintf(os.Stderr, "Error creating schema: %v\n", err)
 		os.Exit(1)
 	}
+	migrateSessionWorkspacesSchema(db)
 	return db
+}
+
+func migrateSessionWorkspacesSchema(db *sql.DB) {
+	var pkCols sql.NullString
+	_ = db.QueryRow(
+		"SELECT group_concat(name, ',') FROM (" +
+			"SELECT name FROM pragma_table_info('session_workspaces') WHERE pk > 0 ORDER BY pk" +
+			")",
+	).Scan(&pkCols)
+	if pkCols.Valid && pkCols.String == "session_id,source" {
+		return
+	}
+	_, _ = db.Exec(`
+ALTER TABLE session_workspaces RENAME TO session_workspaces_old;
+CREATE TABLE session_workspaces (
+    session_id TEXT NOT NULL,
+    cwd TEXT NOT NULL,
+    source TEXT DEFAULT 'local',
+    PRIMARY KEY (session_id, source)
+);
+INSERT OR REPLACE INTO session_workspaces (session_id, cwd, source)
+SELECT session_id, cwd, COALESCE(source, 'local') FROM session_workspaces_old;
+DROP TABLE session_workspaces_old;
+`)
 }
 
 func isLogParsed(db *sql.DB, logFile string, mtime float64, source string) bool {
@@ -544,7 +571,7 @@ func queryProjectStats(db *sql.DB, dateFrom, dateTo string) map[string]*dbModelS
 		"SUM(a.prompt_tokens), SUM(a.completion_tokens), " +
 		"SUM(a.cache_creation_tokens), SUM(a.cache_read_tokens), " +
 		"SUM(CASE WHEN a.is_user_turn = 1 THEN 1 ELSE 0 END) " +
-		"FROM api_calls a LEFT JOIN session_workspaces sw ON a.session_id = sw.session_id" + where +
+		"FROM api_calls a LEFT JOIN session_workspaces sw ON a.session_id = sw.session_id AND a.source = sw.source" + where +
 		" GROUP BY cwd"
 	rows, err := db.Query(q, params...)
 	if err != nil {
@@ -566,7 +593,7 @@ func queryRecords(db *sql.DB, dateFrom, dateTo string) []Record {
 	where, params := buildFilters(dateFrom, dateTo)
 	q := "SELECT model, model_normalized, prompt_tokens, completion_tokens, " +
 		"cache_creation_tokens, cache_read_tokens, is_user_turn, " +
-		"timestamp, session_id, log_file FROM api_calls a" + where
+		"timestamp, session_id, log_file, source FROM api_calls a" + where
 	rows, err := db.Query(q, params...)
 	if err != nil {
 		return nil
@@ -577,10 +604,10 @@ func queryRecords(db *sql.DB, dateFrom, dateTo string) []Record {
 		var r Record
 		var modelNorm string
 		var isUT int
-		var ts, sid, lf sql.NullString
+		var ts, sid, lf, src sql.NullString
 		rows.Scan(&r.Model, &modelNorm, &r.PromptTokens, &r.CompletionTokens,
 			&r.CacheCreationTokens, &r.CacheReadTokens, &isUT,
-			&ts, &sid, &lf)
+			&ts, &sid, &lf, &src)
 		r.IsUserTurn = isUT == 1
 		if ts.Valid {
 			r.Timestamp = ts.String
@@ -591,22 +618,25 @@ func queryRecords(db *sql.DB, dateFrom, dateTo string) []Record {
 		if lf.Valid {
 			r.LogFile = lf.String
 		}
+		if src.Valid {
+			r.Source = src.String
+		}
 		records = append(records, r)
 	}
 	return records
 }
 
 func querySessionWorkspaces(db *sql.DB) map[string]string {
-	rows, err := db.Query("SELECT session_id, cwd FROM session_workspaces")
+	rows, err := db.Query("SELECT session_id, cwd, source FROM session_workspaces")
 	if err != nil {
 		return nil
 	}
 	defer rows.Close()
 	result := make(map[string]string)
 	for rows.Next() {
-		var sid, cwd string
-		rows.Scan(&sid, &cwd)
-		result[sid] = cwd
+		var sid, cwd, source string
+		rows.Scan(&sid, &cwd, &source)
+		result[source+"\x1f"+sid] = cwd
 	}
 	return result
 }
@@ -831,7 +861,7 @@ func listCodespaces(includeStopped bool) []codespaceInfo {
 	return filtered
 }
 
-func syncCodespacesToDB(db *sql.DB, includeStopped bool) int {
+func syncCodespacesToDB(db *sql.DB, includeStopped bool, force bool) int {
 	codespaces := listCodespaces(includeStopped)
 	if len(codespaces) == 0 {
 		return 0
@@ -857,18 +887,28 @@ func syncCodespacesToDB(db *sql.DB, includeStopped bool) int {
 
 			stage := filepath.Join(tmpDir, cs.Name)
 			_ = os.MkdirAll(stage, 0755)
-			cpCmd := exec.Command("gh", "cs", "cp", "-r", "-c", cs.Name, "remote:~/.copilot", stage)
+			cpCmd := exec.Command("gh", "cs", "cp", "-e", "-r", "-c", cs.Name, "remote:/home/vscode/.copilot", stage)
 			cpOut, cpErr := cpCmd.CombinedOutput()
 			if cpErr != nil {
 				msg := strings.TrimSpace(string(cpOut))
-				if msg == "" {
-					msg = "gh cs cp failed"
+				if strings.Contains(msg, "No such file or directory") {
+					fmt.Fprintf(os.Stderr, "  ⚠️ Skipping %s: /home/vscode/.copilot not found\n", cs.Name)
+				} else {
+					if msg == "" {
+						msg = "gh cs cp failed"
+					}
+					fmt.Fprintf(os.Stderr, "  ⚠️ Failed to copy %s: %s\n", cs.Name, msg)
 				}
-				fmt.Fprintf(os.Stderr, "  ⚠️ Failed to copy %s: %s\n", cs.Name, msg)
 				return
 			}
 
 			copilotDir := filepath.Join(stage, ".copilot")
+			if _, err := os.Stat(filepath.Join(copilotDir, "logs")); err != nil {
+				alt := filepath.Join(stage, "home", "vscode", ".copilot")
+				if _, altErr := os.Stat(filepath.Join(alt, "logs")); altErr == nil {
+					copilotDir = alt
+				}
+			}
 			logsDir := filepath.Join(copilotDir, "logs")
 			sessionDir := filepath.Join(copilotDir, "session-state")
 			if _, err := os.Stat(logsDir); err != nil {
@@ -876,7 +916,7 @@ func syncCodespacesToDB(db *sql.DB, includeStopped bool) int {
 				return
 			}
 
-			total += syncLogsToDB(db, logsDir, sessionDir, false, "codespace:"+cs.Name)
+			total += syncLogsToDB(db, logsDir, sessionDir, force, "codespace:"+cs.Name)
 			copied = true
 		}()
 
@@ -1356,7 +1396,7 @@ func main() {
 	}
 
 	if *codespacesSync {
-		syncCodespacesToDB(database, *codespacesIncludeStopped)
+		syncCodespacesToDB(database, *codespacesIncludeStopped, *syncFlag)
 	}
 
 	if *importFile != "" {
@@ -1547,7 +1587,7 @@ func main() {
 		for _, r := range filtered {
 			cwd := ""
 			if r.SessionID != "" {
-				cwd = sessionWorkspaces[r.SessionID]
+				cwd = sessionWorkspaces[r.Source+"\x1f"+r.SessionID]
 			}
 			proj := "(unknown)"
 			if cwd != "" {
@@ -1767,7 +1807,7 @@ func main() {
 	for _, r := range filtered {
 		cwd := ""
 		if r.SessionID != "" {
-			cwd = sessionWorkspaces[r.SessionID]
+			cwd = sessionWorkspaces[r.Source+"\x1f"+r.SessionID]
 		}
 		proj := "(unknown)"
 		if cwd != "" {

--- a/node/copilot-token-cost.js
+++ b/node/copilot-token-cost.js
@@ -82,9 +82,10 @@ CREATE TABLE IF NOT EXISTS parsed_logs (
     PRIMARY KEY (log_file, source)
 );
 CREATE TABLE IF NOT EXISTS session_workspaces (
-    session_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
     cwd TEXT NOT NULL,
-    source TEXT DEFAULT 'local'
+    source TEXT DEFAULT 'local',
+    PRIMARY KEY (session_id, source)
 );
 CREATE TABLE IF NOT EXISTS codespace_sync_state (
     codespace_name TEXT PRIMARY KEY,
@@ -102,7 +103,30 @@ function initDB(dbPath) {
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
   db.exec(SCHEMA_SQL);
+  migrateSessionWorkspacesSchema(db);
   return db;
+}
+
+
+function migrateSessionWorkspacesSchema(db) {
+  const row = db.prepare(
+    "SELECT group_concat(name, ',') AS cols FROM (" +
+    "SELECT name FROM pragma_table_info('session_workspaces') WHERE pk > 0 ORDER BY pk" +
+    ")"
+  ).get();
+  if (row?.cols === 'session_id,source') return;
+  db.exec(`
+ALTER TABLE session_workspaces RENAME TO session_workspaces_old;
+CREATE TABLE session_workspaces (
+    session_id TEXT NOT NULL,
+    cwd TEXT NOT NULL,
+    source TEXT DEFAULT 'local',
+    PRIMARY KEY (session_id, source)
+);
+INSERT OR REPLACE INTO session_workspaces (session_id, cwd, source)
+SELECT session_id, cwd, COALESCE(source, 'local') FROM session_workspaces_old;
+DROP TABLE session_workspaces_old;
+`);
 }
 
 
@@ -238,7 +262,7 @@ function queryProjectStats(db, dateFrom, dateTo, source) {
     'SUM(a.cache_creation_tokens) AS cache_creation_tokens, ' +
     'SUM(a.cache_read_tokens) AS cache_read_tokens, ' +
     'SUM(CASE WHEN a.is_user_turn = 1 THEN 1 ELSE 0 END) AS user_turns ' +
-    `FROM api_calls a LEFT JOIN session_workspaces sw ON a.session_id = sw.session_id${where} ` +
+    `FROM api_calls a LEFT JOIN session_workspaces sw ON a.session_id = sw.session_id AND a.source = sw.source${where} ` +
     'GROUP BY cwd'
   ).all(...params);
   const result = {};
@@ -266,10 +290,10 @@ function queryRecords(db, dateFrom, dateTo, source) {
 
 function querySessionWorkspaces(db, source) {
   const rows = source != null
-    ? db.prepare('SELECT session_id, cwd FROM session_workspaces WHERE source = ?').all(source)
-    : db.prepare('SELECT session_id, cwd FROM session_workspaces').all();
+    ? db.prepare('SELECT session_id, cwd, source FROM session_workspaces WHERE source = ?').all(source)
+    : db.prepare('SELECT session_id, cwd, source FROM session_workspaces').all();
   const result = {};
-  for (const row of rows) result[row.session_id] = row.cwd;
+  for (const row of rows) result[`${row.source}\x1f${row.session_id}`] = row.cwd;
   return result;
 }
 
@@ -418,7 +442,7 @@ function listCodespaces(includeStopped = false) {
 }
 
 
-function syncCodespacesToDB(db, includeStopped = false) {
+function syncCodespacesToDB(db, includeStopped = false, force = false) {
   const codespaces = listCodespaces(includeStopped);
   if (!codespaces.length) return 0;
   let total = 0;
@@ -437,21 +461,29 @@ function syncCodespacesToDB(db, includeStopped = false) {
     try {
       const stage = path.join(tmpDir, name);
       fs.mkdirSync(stage, { recursive: true });
-      const cp = spawnSync('gh', ['cs', 'cp', '-r', '-c', name, 'remote:~/.copilot', stage], { encoding: 'utf-8' });
+      const cp = spawnSync('gh', ['cs', 'cp', '-e', '-r', '-c', name, 'remote:/home/vscode/.copilot', stage], { encoding: 'utf-8' });
       if (cp.status !== 0) {
         const err = (cp.stderr || '').trim();
-        process.stderr.write(`  ⚠️ Failed to copy ${name}: ${err || 'gh cs cp failed'}\n`);
+        if (err.includes('No such file or directory')) {
+          process.stderr.write(`  ⚠️ Skipping ${name}: /home/vscode/.copilot not found\n`);
+        } else {
+          process.stderr.write(`  ⚠️ Failed to copy ${name}: ${err || 'gh cs cp failed'}\n`);
+        }
         continue;
       }
 
-      const copilotDir = path.join(stage, '.copilot');
+      let copilotDir = path.join(stage, '.copilot');
+      if (!fs.existsSync(path.join(copilotDir, 'logs'))) {
+        const alt = path.join(stage, 'home', 'vscode', '.copilot');
+        if (fs.existsSync(path.join(alt, 'logs'))) copilotDir = alt;
+      }
       const logsDir = path.join(copilotDir, 'logs');
       const sessionDir = path.join(copilotDir, 'session-state');
       if (!fs.existsSync(logsDir)) {
         process.stderr.write(`  ⚠️ Skipping ${name}: no .copilot/logs in copied data\n`);
         continue;
       }
-      total += syncLogsToDB(db, logsDir, sessionDir, false, `codespace:${name}`);
+      total += syncLogsToDB(db, logsDir, sessionDir, force, `codespace:${name}`);
       copied = true;
     } finally {
       if (shouldStop) {
@@ -980,7 +1012,7 @@ function main() {
   }
 
   if (args.codespaces_sync) {
-    syncCodespacesToDB(db, args.codespaces_include_stopped);
+    syncCodespacesToDB(db, args.codespaces_include_stopped, args.sync);
   }
 
   if (args.import_file) {
@@ -1141,7 +1173,8 @@ function main() {
     const projCosts = {};
     for (const r of filteredRecords) {
       const sid = r.session_id;
-      const cwd = sid ? (sessionWorkspaces[sid] || '') : '';
+      const source = r.source || '';
+      const cwd = sid ? (sessionWorkspaces[`${source}\x1f${sid}`] || '') : '';
       const proj = cwd ? projectName(cwd) : '(unknown)';
       const model = r.model_normalized;
       const rs = {
@@ -1300,7 +1333,8 @@ function main() {
   const projCosts = {};
   for (const r of filteredRecords) {
     const sid = r.session_id;
-    const cwd = sid ? (sessionWorkspaces[sid] || '') : '';
+    const source = r.source || '';
+    const cwd = sid ? (sessionWorkspaces[`${source}\x1f${sid}`] || '') : '';
     const proj = cwd ? projectName(cwd) : '(unknown)';
     const model = r.model_normalized;
     const rs = {


### PR DESCRIPTION
## Summary
- make codespaces sync copy robust by using gh cs cp -e with /home/vscode/.copilot
- allow --sync to force re-parse for codespace sources as well
- make workspace attribution source-aware (session_id + source) so per-project totals map correctly

## Validation
- python compile check
- gofmt + go build
- node syntax check
- manual forced sync verified codespace rows and project joins